### PR TITLE
Fix message in vswitch.py.

### DIFF
--- a/vswitch.py
+++ b/vswitch.py
@@ -37,7 +37,7 @@ while True:
   # 3. insert/update mac table
   if (eth_src not in mac_table or mac_table[eth_src] != vport_addr):
     mac_table[eth_src] = vport_addr
-    print(f"    ARP Cache: {mac_table}")
+    print(f"    Source Address Table (SAT): {mac_table}")
 
   # 4. forward ethernet frame
   #    if dest in mac table, forward ethernet frame to it


### PR DESCRIPTION
The mapping table on the switch (translating MAC addresses into port numbers) is called a Source Address Table or MAC address table, but is not the ARP Cache.
(The ARP Cache would be on devices like laptops and smartphones mapping IP addresses to MAC addresses.)